### PR TITLE
random_rotate.py

### DIFF
--- a/mmdet/datasets/pipelines/random_rotate.py
+++ b/mmdet/datasets/pipelines/random_rotate.py
@@ -107,6 +107,6 @@ class RandomRotate(object):
         if len(gt_bboxes) == 0:
             return None
         results['gt_bboxes'] = rbox2poly(gt_bboxes).astype(np.float32)
-        results['labels'] = labels.astype(np.uint8)
+        results['gt_labels'] = labels.astype(np.uint8)
 
         return results

--- a/mmdet/datasets/pipelines/random_rotate.py
+++ b/mmdet/datasets/pipelines/random_rotate.py
@@ -107,6 +107,6 @@ class RandomRotate(object):
         if len(gt_bboxes) == 0:
             return None
         results['gt_bboxes'] = rbox2poly(gt_bboxes).astype(np.float32)
-        results['gt_labels'] = labels.astype(np.uint8)
+        results['gt_labels'] = labels
 
         return results

--- a/mmdet/datasets/pipelines/random_rotate.py
+++ b/mmdet/datasets/pipelines/random_rotate.py
@@ -21,7 +21,7 @@ class RandomRotate(object):
 
     @property
     def is_rotate(self):
-        return np.random.rand() > self.rate
+        return np.random.rand() < self.rate
 
     def apply_image(self, img, bound_h, bound_w, interp=cv2.INTER_LINEAR):
         """


### PR DESCRIPTION
debug的时候发现len(results['gt_labels']) > len(results['gt_bboxes'])，看了下代码发现问题发生在旋转增强这一部分，虽然不影响训练过程，但可能会影响网络对类别的学习。
另一个地方是希望旋转增强rate的设置和其他数据增强一样，设为1.0的时候100%触发旋转增强，原先的似乎写反了。
第三个地方results['gt_labels']的数据类型设为uint的话，训练时会触发数据类型不匹配的问题，所以保持数据类型不变。