### PR TITLE
Fix Memory Leak

### DIFF
--- a/mmdet/ops/iou/src/convex_giou_kernel.cu
+++ b/mmdet/ops/iou/src/convex_giou_kernel.cu
@@ -862,6 +862,7 @@ at::Tensor convex_giou_cuda(const at::Tensor ex_boxes, const at::Tensor gt_boxes
         overlaps_out[i] = point_grad_host[i];
     }
     cudaFree(point_grad_dev);
+    free(point_grad_host);
     // TODO improve this part
     return overlaps.to(ex_boxes.device());//, point_grad.to(ex_boxes.device());
 }


### PR DESCRIPTION
有个动态分配内存的变量没被释放，只有在训练程序终止的时候才会得到释放。
训练时间过长或数据集较大时会引发内存不足的问题。